### PR TITLE
[Feat]#2 Notice 및 NoticeCheck 작성 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ out/
 application.yml
 application-local.yml
 .env
+
+### Generated Q classes ###
+src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+//추가
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.7'
@@ -10,6 +17,7 @@ version = '0.0.1-SNAPSHOT'
 java {
 	sourceCompatibility = '17'
 }
+
 
 configurations {
 	compileOnly {
@@ -40,6 +48,12 @@ dependencies {
 	implementation 'io.springfox:springfox-swagger2:2.9.2'
 	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 
+	// Querydsl 추가
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -52,4 +66,22 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }

--- a/src/main/java/UMC/WithYou/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC/WithYou/common/apiPayload/code/status/ErrorStatus.java
@@ -14,9 +14,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "권한이 없습니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "권한이 없습니다."),
 
-
+    _NOTICE_NOT_FOUND(HttpStatus.BAD_REQUEST,"NOTICE4003","공지가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/UMC/WithYou/common/validation/annotation/ExistNotices.java
+++ b/src/main/java/UMC/WithYou/common/validation/annotation/ExistNotices.java
@@ -1,0 +1,17 @@
+package UMC.WithYou.common.validation.annotation;
+
+import UMC.WithYou.common.validation.validator.NoticesExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = NoticesExistValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistNotices {
+    String message() default "해당하는 공지가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/UMC/WithYou/common/validation/validator/NoticesExistValidator.java
+++ b/src/main/java/UMC/WithYou/common/validation/validator/NoticesExistValidator.java
@@ -1,0 +1,33 @@
+package UMC.WithYou.common.validation.validator;
+
+import UMC.WithYou.common.apiPayload.code.status.ErrorStatus;
+import UMC.WithYou.repository.notice.NoticeRepository;
+import UMC.WithYou.common.validation.annotation.ExistNotices;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NoticesExistValidator implements ConstraintValidator<ExistNotices, Long> {
+
+    private final NoticeRepository noticeRepository;
+
+    @Override
+    public void initialize(ExistNotices constraintAnnotation){
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context){
+        boolean isValid=noticeRepository.existsById(value);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus._NOTICE_NOT_FOUND.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/UMC/WithYou/controller/NoticeCheckController.java
+++ b/src/main/java/UMC/WithYou/controller/NoticeCheckController.java
@@ -1,0 +1,45 @@
+package UMC.WithYou.controller;
+
+import UMC.WithYou.common.apiPayload.ApiResponse;
+import UMC.WithYou.converter.NoticeCheckConverter;
+import UMC.WithYou.converter.NoticeConverter;
+import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.domain.notice.NoticeCheck;
+import UMC.WithYou.dto.NoticeCheckResponseDTO;
+import UMC.WithYou.dto.NoticeResponseDTO;
+import UMC.WithYou.service.notice.NoticeCheckCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/api/v1/noticeCheck")
+public class NoticeCheckController {
+
+    private final NoticeCheckCommandService noticeCheckCommandService;
+
+    @Operation(summary="notice 체크 API")
+    @PatchMapping("/{noticeId}")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE2000",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE4023", description = "해당 notice가 없습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "noticeId", description = "notice 의 아이디, path variable 입니다!"),
+    })
+    public ApiResponse<NoticeCheckResponseDTO.ResultDto> checkBox(@PathVariable Long noticeId){
+        NoticeCheck noticeCheck=noticeCheckCommandService.checkBox(noticeId);
+        return ApiResponse.onSuccess(NoticeCheckConverter.toResultDTO(noticeCheck));
+    }
+}

--- a/src/main/java/UMC/WithYou/controller/NoticeController.java
+++ b/src/main/java/UMC/WithYou/controller/NoticeController.java
@@ -3,6 +3,7 @@ package UMC.WithYou.controller;
 import UMC.WithYou.common.apiPayload.ApiResponse;
 import UMC.WithYou.converter.NoticeConverter;
 import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.dto.NoticeCheckResponseDTO;
 import UMC.WithYou.dto.NoticeRequestDTO;
 import UMC.WithYou.dto.NoticeResponseDTO;
 import UMC.WithYou.service.notice.NoticeCommandService;
@@ -16,6 +17,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -52,7 +57,7 @@ public class NoticeController {
         return ApiResponse.onSuccess(NoticeConverter.toJoinResultDTO(notice));
     }
 
-    @Operation(summary="notice 조회 API")
+    @Operation(summary="notice 단건 조회 API")
     @GetMapping("/{noticeId}")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE2000",description = "OK, 성공"),
@@ -66,6 +71,35 @@ public class NoticeController {
         return ApiResponse.onSuccess(NoticeConverter.toResultDTO(notice));
     }
 
+    @Operation(summary="travelLog에 따른 notice 모두 조회 API")
+    @GetMapping("/logs/{noticeId}")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE2000",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TRAVEL4003", description = "해당 travel log가 없습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "logId", description = "travel log 의 아이디, path variable 입니다!"),
+    })
+    public ApiResponse<List<NoticeCheckResponseDTO.ShortResponseDto>> getTravelNotice(@PathVariable Long travelId){
+        List<NoticeCheckResponseDTO.ShortResponseDto> notices=noticeCommandService.getTravelNotice(travelId);
+        return ApiResponse.onSuccess(notices);
+    }
+
+    @Operation(summary="날짜에 따른 notice 모두 조회 API")
+    @GetMapping("/date/{noticeId}")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE2000",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TRAVEL4003", description = "해당 travel log가 없습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "logId", description = "travel log 의 아이디, path variable 입니다!"),
+            @Parameter(name = "checkDate", description = "현재 날짜, path variable 입니다!"),
+    })
+    public ApiResponse<List<NoticeCheckResponseDTO.ShortResponseDto>> getDateNotice
+            (@PathVariable Long travelId, @PathVariable LocalDateTime checkDate){
+        List<NoticeCheckResponseDTO.ShortResponseDto> notices=noticeCommandService.getDateNotice(travelId,checkDate);
+        return ApiResponse.onSuccess(notices);
+    }
 
     @Operation(summary="notice 수정 API")
     @PatchMapping

--- a/src/main/java/UMC/WithYou/controller/NoticeController.java
+++ b/src/main/java/UMC/WithYou/controller/NoticeController.java
@@ -1,0 +1,80 @@
+package UMC.WithYou.controller;
+
+import UMC.WithYou.common.apiPayload.ApiResponse;
+import UMC.WithYou.converter.NoticeConverter;
+import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.dto.NoticeRequestDTO;
+import UMC.WithYou.dto.NoticeResponseDTO;
+import UMC.WithYou.service.notice.NoticeCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/api/v1/notice")
+public class NoticeController {
+
+    private final NoticeCommandService noticeCommandService;
+
+    @Operation(summary="notice 생성 API")
+    @PostMapping
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE2000",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4003", description = "해당 member가 없습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "LOG4013", description = "해당 로그가 없습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<NoticeResponseDTO.JoinResultDto> create(@RequestBody @Valid NoticeRequestDTO.JoinDto request){
+        Notice notice= noticeCommandService.createNotice(request);
+        return ApiResponse.onSuccess(NoticeConverter.toJoinResultDTO(notice));
+    }
+
+
+    @Operation(summary="notice 삭제 API")
+    @DeleteMapping("/{noticeId}")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE2000",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE4023", description = "해당 notice가 없습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "noticeId", description = "notice 의 아이디, path variable 입니다!"),
+    })
+    public ApiResponse<NoticeResponseDTO.JoinResultDto> delete(@PathVariable Long noticeId){
+        Notice notice=noticeCommandService.delete(noticeId);
+        return ApiResponse.onSuccess(NoticeConverter.toJoinResultDTO(notice));
+    }
+
+    @Operation(summary="notice 조회 API")
+    @GetMapping("/{noticeId}")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE2000",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE4023", description = "해당 notice가 없습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "noticeId", description = "notice 의 아이디, path variable 입니다!"),
+    })
+    public ApiResponse<NoticeResponseDTO.ResultDto> getNotice(@PathVariable Long noticeId){
+        Notice notice=noticeCommandService.getNotice(noticeId);
+        return ApiResponse.onSuccess(NoticeConverter.toResultDTO(notice));
+    }
+
+
+    @Operation(summary="notice 수정 API")
+    @PatchMapping
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE2000",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE4023", description = "해당 notice가 없습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<NoticeResponseDTO.JoinResultDto> fix(@RequestBody @Valid NoticeRequestDTO.FixDto request){
+        Notice notice=noticeCommandService.fix(request);
+        return ApiResponse.onSuccess(NoticeConverter.toJoinResultDTO(notice));
+    }
+}

--- a/src/main/java/UMC/WithYou/converter/NoticeCheckConverter.java
+++ b/src/main/java/UMC/WithYou/converter/NoticeCheckConverter.java
@@ -1,0 +1,35 @@
+package UMC.WithYou.converter;
+
+import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.domain.notice.NoticeCheck;
+import UMC.WithYou.dto.NoticeCheckResponseDTO;
+import UMC.WithYou.dto.NoticeResponseDTO;
+
+public class NoticeCheckConverter {
+
+    public static NoticeCheckResponseDTO.ResultDto toResultDTO(NoticeCheck notice){ //조회용
+        return NoticeCheckResponseDTO.ResultDto.builder()
+                .noticeId(notice.getId())
+                .createdAt(notice.getCreatedAt())
+                .build();
+    }
+
+    public static NoticeCheck toChangeNoticeCheck(NoticeCheck noticeCheck){
+        boolean checkStatus=false;
+        if (!noticeCheck.isChecked())
+            checkStatus=true;
+
+        return NoticeCheck.builder()
+                .id(noticeCheck.getId())
+                .notice(noticeCheck.getNotice())
+                .isChecked(checkStatus)
+                .build();
+    }
+
+    public static NoticeCheck toJoinDTO(Notice notices){
+        return NoticeCheck.builder()
+                .isChecked(false)
+                .notice(notices)
+                .build();
+    }
+}

--- a/src/main/java/UMC/WithYou/converter/NoticeConverter.java
+++ b/src/main/java/UMC/WithYou/converter/NoticeConverter.java
@@ -1,6 +1,7 @@
 package UMC.WithYou.converter;
 
 import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.dto.NoticeCheckResponseDTO;
 import UMC.WithYou.dto.NoticeRequestDTO;
 import UMC.WithYou.dto.NoticeResponseDTO;
 
@@ -39,5 +40,12 @@ public class NoticeConverter {
 
     }
 
+    public static NoticeCheckResponseDTO.ShortResponseDto toSearch(Notice notice, int checkNum){
+        return NoticeCheckResponseDTO.ShortResponseDto.builder()
+                .content(notice.getContent())
+                .checkNum(checkNum)
+                .name(notice.getMember().getName())
+                .build();
+    }
 
 }

--- a/src/main/java/UMC/WithYou/converter/NoticeConverter.java
+++ b/src/main/java/UMC/WithYou/converter/NoticeConverter.java
@@ -1,0 +1,43 @@
+package UMC.WithYou.converter;
+
+import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.dto.NoticeRequestDTO;
+import UMC.WithYou.dto.NoticeResponseDTO;
+
+public class NoticeConverter {
+
+    public static NoticeResponseDTO.JoinResultDto toJoinResultDTO(Notice notice){
+        return NoticeResponseDTO.JoinResultDto.builder()
+                .noticeId(notice.getId())
+                .createdAt(notice.getCreatedAt())
+                .build();
+    }
+
+    public static NoticeResponseDTO.ResultDto toResultDTO(Notice notice){ //조회용
+        return NoticeResponseDTO.ResultDto.builder()
+                .startAt(notice.getStartDate())
+                .endAt(notice.getEndDate())
+                .content(notice.getContent())
+                .build();
+    }
+
+    public static Notice toFixNotice(NoticeRequestDTO.FixDto request){
+        return Notice.builder()
+                .id(request.getNoticeId())
+                .content(request.getContent())
+                .endDate(request.getEndDate())
+                .startDate(request.getStartDate())
+                .build();
+    }
+
+    public static Notice toNotice(NoticeRequestDTO.JoinDto request){ //미완성
+        return Notice.builder()
+                .content(request.getContent())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .build();
+
+    }
+
+
+}

--- a/src/main/java/UMC/WithYou/domain/notice/Notice.java
+++ b/src/main/java/UMC/WithYou/domain/notice/Notice.java
@@ -1,0 +1,41 @@
+package UMC.WithYou.domain.notice;
+
+import UMC.WithYou.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    LocalDateTime startDate;
+
+    LocalDateTime endDate;
+
+
+//    @OneToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name="member_id")
+//    private Member member;    //노티스를 만든사람
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name="log_id")
+//    private TravelLog travelLog;
+
+
+}

--- a/src/main/java/UMC/WithYou/domain/notice/Notice.java
+++ b/src/main/java/UMC/WithYou/domain/notice/Notice.java
@@ -1,6 +1,7 @@
 package UMC.WithYou.domain.notice;
 
 import UMC.WithYou.domain.BaseEntity;
+import UMC.WithYou.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -29,9 +30,9 @@ public class Notice extends BaseEntity {
     LocalDateTime endDate;
 
 
-//    @OneToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="member_id")
-//    private Member member;    //노티스를 만든사람
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="member_id")
+    private Member member;    //노티스를 만든사람
 
 //    @ManyToOne(fetch = FetchType.LAZY)
 //    @JoinColumn(name="log_id")

--- a/src/main/java/UMC/WithYou/domain/notice/NoticeCheck.java
+++ b/src/main/java/UMC/WithYou/domain/notice/NoticeCheck.java
@@ -2,6 +2,7 @@ package UMC.WithYou.domain.notice;
 
 
 import UMC.WithYou.domain.BaseEntity;
+import UMC.WithYou.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -22,11 +23,11 @@ public class NoticeCheck extends BaseEntity {
 
     private boolean isChecked;
 
-//    @OneToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="member_id")
-//    private Member member;    //체크한 사람
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="member_id")
+    private Member member;    //체크한 사람
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="notice_id")
     private Notice notice;
 

--- a/src/main/java/UMC/WithYou/domain/notice/NoticeCheck.java
+++ b/src/main/java/UMC/WithYou/domain/notice/NoticeCheck.java
@@ -1,0 +1,34 @@
+package UMC.WithYou.domain.notice;
+
+
+import UMC.WithYou.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NoticeCheck extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private boolean isChecked;
+
+//    @OneToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name="member_id")
+//    private Member member;    //체크한 사람
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="notice_id")
+    private Notice notice;
+
+}
+

--- a/src/main/java/UMC/WithYou/dto/NoticeCheckResponseDTO.java
+++ b/src/main/java/UMC/WithYou/dto/NoticeCheckResponseDTO.java
@@ -1,0 +1,19 @@
+package UMC.WithYou.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class NoticeCheckResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResultDto{
+        Long noticeId;
+        LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/UMC/WithYou/dto/NoticeCheckResponseDTO.java
+++ b/src/main/java/UMC/WithYou/dto/NoticeCheckResponseDTO.java
@@ -16,4 +16,24 @@ public class NoticeCheckResponseDTO {
         Long noticeId;
         LocalDateTime createdAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ShortResponseDto{ //NoticeCheckResponseDTO.ShortResponseDto
+        //String url;       //공지 쓴 멤버 사진
+        String name;      //공지 쓴 멤버 이름
+        String content;
+        int checkNum;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ShortDto{
+        //String url;       //공지 쓴 멤버 사진
+        String name;      //공지 쓴 멤버 이름
+    }
 }

--- a/src/main/java/UMC/WithYou/dto/NoticeRequestDTO.java
+++ b/src/main/java/UMC/WithYou/dto/NoticeRequestDTO.java
@@ -1,0 +1,39 @@
+package UMC.WithYou.dto;
+
+import UMC.WithYou.common.validation.annotation.ExistNotices;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class NoticeRequestDTO {
+
+    @Getter
+    public static class JoinDto{
+
+        //@ExistMember
+        Long memberId;
+
+        //@ExistLog
+        Long logId;
+
+        LocalDateTime startDate;
+
+        LocalDateTime endDate;
+
+        String content;
+    }
+
+    @Getter
+    public static class FixDto{
+
+        @ExistNotices
+        Long noticeId;
+
+        LocalDateTime startDate;
+
+        LocalDateTime endDate;
+
+        String content;
+    }
+
+}

--- a/src/main/java/UMC/WithYou/dto/NoticeResponseDTO.java
+++ b/src/main/java/UMC/WithYou/dto/NoticeResponseDTO.java
@@ -1,0 +1,29 @@
+package UMC.WithYou.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class NoticeResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class JoinResultDto{
+        Long noticeId;
+        LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResultDto{
+        String content;
+        LocalDateTime startAt;
+        LocalDateTime endAt;
+    }
+}

--- a/src/main/java/UMC/WithYou/repository/notice/NoticeCheckRepository.java
+++ b/src/main/java/UMC/WithYou/repository/notice/NoticeCheckRepository.java
@@ -1,0 +1,13 @@
+package UMC.WithYou.repository.notice;
+
+import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.domain.notice.NoticeCheck;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NoticeCheckRepository extends JpaRepository<NoticeCheck,Long> {
+    Optional<NoticeCheck> findByNotice(Notice notice);
+    List<NoticeCheck> findAllByIsCheckedIsTrueAndNotice(Long noticeId);
+}

--- a/src/main/java/UMC/WithYou/repository/notice/NoticeCheckRepository.java
+++ b/src/main/java/UMC/WithYou/repository/notice/NoticeCheckRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 public interface NoticeCheckRepository extends JpaRepository<NoticeCheck,Long> {
     Optional<NoticeCheck> findByNotice(Notice notice);
-    List<NoticeCheck> findAllByIsCheckedIsTrueAndNotice(Long noticeId);
+    List<NoticeCheck> findAllByIsCheckedIsTrueAndNotice(Notice notice);
 }

--- a/src/main/java/UMC/WithYou/repository/notice/NoticeRepository.java
+++ b/src/main/java/UMC/WithYou/repository/notice/NoticeRepository.java
@@ -3,6 +3,8 @@ package UMC.WithYou.repository.notice;
 import UMC.WithYou.domain.notice.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NoticeRepository extends JpaRepository<Notice,Long> {
-    //Page<Notice> findAllByTravelLog(TravelLog log, PageRequest pageRequest);
+    //List<Notice> findAllByTravel(Long travelId);
 }

--- a/src/main/java/UMC/WithYou/repository/notice/NoticeRepository.java
+++ b/src/main/java/UMC/WithYou/repository/notice/NoticeRepository.java
@@ -1,0 +1,8 @@
+package UMC.WithYou.repository.notice;
+
+import UMC.WithYou.domain.notice.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice,Long> {
+    //Page<Notice> findAllByTravelLog(TravelLog log, PageRequest pageRequest);
+}

--- a/src/main/java/UMC/WithYou/repository/notice/NoticeRepositoryCustom.java
+++ b/src/main/java/UMC/WithYou/repository/notice/NoticeRepositoryCustom.java
@@ -1,0 +1,9 @@
+package UMC.WithYou.repository.notice;
+
+import UMC.WithYou.domain.notice.Notice;
+
+import java.util.List;
+
+public interface NoticeRepositoryCustom {
+    List<Notice> findByTravelLogFetchJoinMember(Long travelId);
+}

--- a/src/main/java/UMC/WithYou/repository/notice/NoticeRepositoryCustomImpl.java
+++ b/src/main/java/UMC/WithYou/repository/notice/NoticeRepositoryCustomImpl.java
@@ -1,0 +1,25 @@
+package UMC.WithYou.repository.notice;
+
+import UMC.WithYou.domain.notice.Notice;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static UMC.WithYou.domain.member.QMember.member;
+import static UMC.WithYou.domain.notice.QNotice.notice;
+
+@RequiredArgsConstructor
+public class NoticeRepositoryCustomImpl{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+//    @Override
+//    public List<Notice> findByTravelLogFetchJoinMember(Long travelId){
+//        return jpaQueryFactory
+//                .selectFrom(notice)
+//                .join(notice.member,member).fetchJoin()
+//                .where(notice.travelLog.id.eq(travelId))
+//                .fetch();
+//    }
+}

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCheckCommandService.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCheckCommandService.java
@@ -1,0 +1,7 @@
+package UMC.WithYou.service.notice;
+
+import UMC.WithYou.domain.notice.NoticeCheck;
+
+public interface NoticeCheckCommandService {
+    NoticeCheck checkBox(Long noticeId);
+}

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCheckCommandServiceImpl.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCheckCommandServiceImpl.java
@@ -1,0 +1,34 @@
+package UMC.WithYou.service.notice;
+
+import UMC.WithYou.common.apiPayload.code.status.ErrorStatus;
+import UMC.WithYou.common.apiPayload.exception.handler.CommonErrorHandler;
+import UMC.WithYou.converter.NoticeCheckConverter;
+import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.domain.notice.NoticeCheck;
+import UMC.WithYou.repository.notice.NoticeCheckRepository;
+import UMC.WithYou.repository.notice.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeCheckCommandServiceImpl implements NoticeCheckCommandService{
+
+    private final NoticeCheckRepository noticeCheckRepository;
+    private final NoticeRepository noticeRepository;
+
+    @Override
+    @Transactional
+    public NoticeCheck checkBox(Long noticeId){
+        Notice notice= noticeRepository.findById(noticeId)
+                .orElseThrow(()->new CommonErrorHandler(ErrorStatus._NOTICE_NOT_FOUND));
+        NoticeCheck noticeCheck=noticeCheckRepository.findByNotice(notice).get();
+
+        NoticeCheck newNoticeCheck= NoticeCheckConverter.toChangeNoticeCheck(noticeCheck);
+        noticeCheckRepository.save(newNoticeCheck);
+        return newNoticeCheck;
+    }
+}

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCommandService.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCommandService.java
@@ -1,7 +1,11 @@
 package UMC.WithYou.service.notice;
 
 import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.dto.NoticeCheckResponseDTO;
 import UMC.WithYou.dto.NoticeRequestDTO;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface NoticeCommandService {
 
@@ -12,4 +16,8 @@ public interface NoticeCommandService {
     Notice fix(NoticeRequestDTO.FixDto request);
 
     Notice getNotice(Long noticeId);
+
+    List<NoticeCheckResponseDTO.ShortResponseDto> getTravelNotice(Long travelId);
+
+    List<NoticeCheckResponseDTO.ShortResponseDto> getDateNotice(Long travelId, LocalDateTime checkDate);
 }

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCommandService.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCommandService.java
@@ -1,0 +1,15 @@
+package UMC.WithYou.service.notice;
+
+import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.dto.NoticeRequestDTO;
+
+public interface NoticeCommandService {
+
+    Notice createNotice(NoticeRequestDTO.JoinDto request);
+
+    Notice delete(Long noticeId);
+
+    Notice fix(NoticeRequestDTO.FixDto request);
+
+    Notice getNotice(Long noticeId);
+}

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCommandServiceImpl.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCommandServiceImpl.java
@@ -4,12 +4,17 @@ import UMC.WithYou.converter.NoticeCheckConverter;
 import UMC.WithYou.converter.NoticeConverter;
 import UMC.WithYou.domain.notice.Notice;
 import UMC.WithYou.domain.notice.NoticeCheck;
+import UMC.WithYou.dto.NoticeCheckResponseDTO;
 import UMC.WithYou.dto.NoticeRequestDTO;
 import UMC.WithYou.repository.notice.NoticeCheckRepository;
 import UMC.WithYou.repository.notice.NoticeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +23,45 @@ public class NoticeCommandServiceImpl implements NoticeCommandService{
 
     private final NoticeRepository noticeRepository;
     private final NoticeCheckRepository noticeCheckRepository;
+
+    private static boolean isBetween(LocalDateTime dateTime, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return dateTime.isAfter(startDateTime) && dateTime.isBefore(endDateTime);
+    }
+
+
+    @Override
+    public List<NoticeCheckResponseDTO.ShortResponseDto> getDateNotice(Long travelId, LocalDateTime checkDate){
+        List<NoticeCheckResponseDTO.ShortResponseDto> results = new ArrayList<>();
+//        List<Notice> notices=noticeRepository.findByTravelLogFetchJoinMember(travelId);
+//
+//        for(Notice notice : notices){
+//            if (!isBetween(checkDate,notice.getStartDate(),notice.getEndDate()))
+//                break;
+//
+//            List<NoticeCheck> noticeChecks=noticeCheckRepository
+//                    .findAllByIsCheckedIsTrueAndNotice(notice);
+//
+//            NoticeCheckResponseDTO.ShortResponseDto check = NoticeConverter.toSearch(notice, noticeChecks.size());
+//            results.add(check);
+//        }
+        return results;
+    }
+
+
+    @Override
+    public List<NoticeCheckResponseDTO.ShortResponseDto> getTravelNotice(Long travelId){
+        List<NoticeCheckResponseDTO.ShortResponseDto> results = new ArrayList<>();
+//        List<Notice> notices=noticeRepository.findByTravelLogFetchJoinMember(travelId);
+//
+//        for(Notice notice : notices){
+//            List<NoticeCheck> noticeChecks=noticeCheckRepository
+//                    .findAllByIsCheckedIsTrueAndNotice(notice);
+//
+//            NoticeCheckResponseDTO.ShortResponseDto check = NoticeConverter.toSearch(notice, noticeChecks.size());
+//            results.add(check);
+//        }
+        return results;
+    }
 
     @Override
     @Transactional

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCommandServiceImpl.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCommandServiceImpl.java
@@ -1,0 +1,58 @@
+package UMC.WithYou.service.notice;
+
+import UMC.WithYou.converter.NoticeCheckConverter;
+import UMC.WithYou.converter.NoticeConverter;
+import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.domain.notice.NoticeCheck;
+import UMC.WithYou.dto.NoticeRequestDTO;
+import UMC.WithYou.repository.notice.NoticeCheckRepository;
+import UMC.WithYou.repository.notice.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeCommandServiceImpl implements NoticeCommandService{
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeCheckRepository noticeCheckRepository;
+
+    @Override
+    @Transactional
+    public Notice createNotice(NoticeRequestDTO.JoinDto request){
+        Notice newNotice= NoticeConverter.toNotice(request);
+        Notice notice=noticeRepository.save(newNotice);
+
+        NoticeCheck newNoticeCheck= NoticeCheckConverter.toJoinDTO(notice);
+        noticeCheckRepository.save(newNoticeCheck);
+
+        return notice;
+    }
+
+    @Override
+    public Notice delete(Long noticeId){
+        Notice notice= noticeRepository.findById(noticeId).get();
+        noticeRepository.deleteById(noticeId);
+
+        return notice;
+    }
+
+    @Override
+    @Transactional
+    public Notice fix(NoticeRequestDTO.FixDto request){
+        Notice notice= noticeRepository.findById(request.getNoticeId()).get();
+        Notice newNotice=NoticeConverter.toFixNotice(request);
+
+        noticeRepository.save(newNotice);
+        return notice;
+    }
+
+    @Override
+    public Notice getNotice(Long noticeId){
+        Notice notice= noticeRepository.findById(noticeId).get();
+
+        return notice;
+    }
+}


### PR DESCRIPTION
## #️⃣ 2

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 
- notice 체크 API
- notice 생성 API
- notice 삭제 API
- notice 단건 조회 API
- travelLog에 따른 notice 모두 조회 API
- 날짜에 따른 notice 모두 조회 API
- notice 수정 API

## 💬 리뷰 중점 사안(선택)

![스크린샷 2024-01-25 112032](https://github.com/UMC-with-you/WithYouServer/assets/72841908/64a11324-7f16-4b99-9bd4-2bca21a687a8)

Member와 Notice의 패치조인에 대한 querydsl 사용

![스크린샷 2024-01-25 111901](https://github.com/UMC-with-you/WithYouServer/assets/72841908/282c0135-b710-43b4-932a-8f7eed03988c)

패치조인된 Notice에 해당하는 noticeCheck을 끌어온 뒤 DTO로 바꾸어 반환
