### PR TITLE
[REFACTOR]#22 Notice 및 NoticeCheck 리펙토링

### DIFF
--- a/src/main/java/UMC/WithYou/controller/NoticeCheckController.java
+++ b/src/main/java/UMC/WithYou/controller/NoticeCheckController.java
@@ -37,9 +37,10 @@ public class NoticeCheckController {
     })
     @Parameters({
             @Parameter(name = "noticeId", description = "notice 의 아이디, path variable 입니다!"),
+            @Parameter(name = "memberId", description = "notice 의 아이디, path variable 입니다!"),
     })
-    public ApiResponse<NoticeCheckResponseDTO.ResultDto> checkBox(@PathVariable Long noticeId){
-        NoticeCheck noticeCheck=noticeCheckCommandService.checkBox(noticeId);
+    public ApiResponse<NoticeCheckResponseDTO.ResultDto> checkBox(@PathVariable Long noticeId,@PathVariable Long memberId){
+        NoticeCheck noticeCheck=noticeCheckCommandService.checkBox(noticeId,memberId);
         return ApiResponse.onSuccess(NoticeCheckConverter.toResultDTO(noticeCheck));
     }
 }

--- a/src/main/java/UMC/WithYou/converter/NoticeCheckConverter.java
+++ b/src/main/java/UMC/WithYou/converter/NoticeCheckConverter.java
@@ -1,7 +1,9 @@
 package UMC.WithYou.converter;
 
+import UMC.WithYou.domain.member.Member;
 import UMC.WithYou.domain.notice.Notice;
 import UMC.WithYou.domain.notice.NoticeCheck;
+import UMC.WithYou.domain.travel.Travel;
 import UMC.WithYou.dto.NoticeCheckResponseDTO;
 import UMC.WithYou.dto.NoticeResponseDTO;
 
@@ -14,21 +16,23 @@ public class NoticeCheckConverter {
                 .build();
     }
 
-    public static NoticeCheck toChangeNoticeCheck(NoticeCheck noticeCheck){
+    public static NoticeCheck toChangeNoticeCheck(NoticeCheck noticeCheck,Member member,Notice notice){
         boolean checkStatus=false;
         if (!noticeCheck.isChecked())
             checkStatus=true;
 
         return NoticeCheck.builder()
                 .id(noticeCheck.getId())
-                .notice(noticeCheck.getNotice())
+                .member(member)
+                .notice(notice)
                 .isChecked(checkStatus)
                 .build();
     }
 
-    public static NoticeCheck toJoinDTO(Notice notices){
+    public static NoticeCheck toJoinDTO(Notice notices,Member member){
         return NoticeCheck.builder()
                 .isChecked(false)
+                .member(member)
                 .notice(notices)
                 .build();
     }

--- a/src/main/java/UMC/WithYou/converter/NoticeConverter.java
+++ b/src/main/java/UMC/WithYou/converter/NoticeConverter.java
@@ -1,6 +1,8 @@
 package UMC.WithYou.converter;
 
+import UMC.WithYou.domain.member.Member;
 import UMC.WithYou.domain.notice.Notice;
+import UMC.WithYou.domain.travel.Travel;
 import UMC.WithYou.dto.NoticeCheckResponseDTO;
 import UMC.WithYou.dto.NoticeRequestDTO;
 import UMC.WithYou.dto.NoticeResponseDTO;
@@ -31,9 +33,11 @@ public class NoticeConverter {
                 .build();
     }
 
-    public static Notice toNotice(NoticeRequestDTO.JoinDto request){ //미완성
+    public static Notice toNotice(NoticeRequestDTO.JoinDto request, Member member, Travel travel){
         return Notice.builder()
                 .content(request.getContent())
+                .member(member)
+                .travel(travel)
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
                 .build();
@@ -43,6 +47,7 @@ public class NoticeConverter {
     public static NoticeCheckResponseDTO.ShortResponseDto toSearch(Notice notice, int checkNum){
         return NoticeCheckResponseDTO.ShortResponseDto.builder()
                 .content(notice.getContent())
+                .url(notice.getMember().getImageUrl())
                 .checkNum(checkNum)
                 .name(notice.getMember().getName())
                 .build();

--- a/src/main/java/UMC/WithYou/domain/notice/Notice.java
+++ b/src/main/java/UMC/WithYou/domain/notice/Notice.java
@@ -2,6 +2,7 @@ package UMC.WithYou.domain.notice;
 
 import UMC.WithYou.domain.BaseEntity;
 import UMC.WithYou.domain.member.Member;
+import UMC.WithYou.domain.travel.Travel;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -34,9 +35,9 @@ public class Notice extends BaseEntity {
     @JoinColumn(name="member_id")
     private Member member;    //노티스를 만든사람
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="log_id")
-//    private TravelLog travelLog;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="log_id")
+    private Travel travel;
 
 
 }

--- a/src/main/java/UMC/WithYou/dto/NoticeCheckResponseDTO.java
+++ b/src/main/java/UMC/WithYou/dto/NoticeCheckResponseDTO.java
@@ -21,8 +21,8 @@ public class NoticeCheckResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ShortResponseDto{ //NoticeCheckResponseDTO.ShortResponseDto
-        //String url;       //공지 쓴 멤버 사진
+    public static class ShortResponseDto{
+        String url;       //공지 쓴 멤버 사진
         String name;      //공지 쓴 멤버 이름
         String content;
         int checkNum;
@@ -33,7 +33,7 @@ public class NoticeCheckResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ShortDto{
-        //String url;       //공지 쓴 멤버 사진
+        String url;       //공지 쓴 멤버 사진
         String name;      //공지 쓴 멤버 이름
     }
 }

--- a/src/main/java/UMC/WithYou/repository/notice/NoticeCheckRepository.java
+++ b/src/main/java/UMC/WithYou/repository/notice/NoticeCheckRepository.java
@@ -1,5 +1,6 @@
 package UMC.WithYou.repository.notice;
 
+import UMC.WithYou.domain.member.Member;
 import UMC.WithYou.domain.notice.Notice;
 import UMC.WithYou.domain.notice.NoticeCheck;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,5 @@ import java.util.Optional;
 public interface NoticeCheckRepository extends JpaRepository<NoticeCheck,Long> {
     Optional<NoticeCheck> findByNotice(Notice notice);
     List<NoticeCheck> findAllByIsCheckedIsTrueAndNotice(Notice notice);
+    Optional<NoticeCheck> findByMemberAndNotice(Member member, Notice notice);
 }

--- a/src/main/java/UMC/WithYou/repository/notice/NoticeRepository.java
+++ b/src/main/java/UMC/WithYou/repository/notice/NoticeRepository.java
@@ -6,5 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface NoticeRepository extends JpaRepository<Notice,Long> {
-    //List<Notice> findAllByTravel(Long travelId);
 }

--- a/src/main/java/UMC/WithYou/repository/notice/NoticeRepositoryCustomImpl.java
+++ b/src/main/java/UMC/WithYou/repository/notice/NoticeRepositoryCustomImpl.java
@@ -10,16 +10,16 @@ import static UMC.WithYou.domain.member.QMember.member;
 import static UMC.WithYou.domain.notice.QNotice.notice;
 
 @RequiredArgsConstructor
-public class NoticeRepositoryCustomImpl{
+public class NoticeRepositoryCustomImpl implements NoticeRepositoryCustom{
 
     private final JPAQueryFactory jpaQueryFactory;
 
-//    @Override
-//    public List<Notice> findByTravelLogFetchJoinMember(Long travelId){
-//        return jpaQueryFactory
-//                .selectFrom(notice)
-//                .join(notice.member,member).fetchJoin()
-//                .where(notice.travelLog.id.eq(travelId))
-//                .fetch();
-//    }
+    @Override
+    public List<Notice> findByTravelLogFetchJoinMember(Long travelId){
+        return jpaQueryFactory
+                .selectFrom(notice)
+                .join(notice.member,member).fetchJoin()
+                .where(notice.travel.id.eq(travelId))
+                .fetch();
+    }
 }

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCheckCommandService.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCheckCommandService.java
@@ -3,5 +3,5 @@ package UMC.WithYou.service.notice;
 import UMC.WithYou.domain.notice.NoticeCheck;
 
 public interface NoticeCheckCommandService {
-    NoticeCheck checkBox(Long noticeId);
+    NoticeCheck checkBox(Long noticeId, Long memberId);
 }

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCheckCommandServiceImpl.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCheckCommandServiceImpl.java
@@ -3,13 +3,17 @@ package UMC.WithYou.service.notice;
 import UMC.WithYou.common.apiPayload.code.status.ErrorStatus;
 import UMC.WithYou.common.apiPayload.exception.handler.CommonErrorHandler;
 import UMC.WithYou.converter.NoticeCheckConverter;
+import UMC.WithYou.domain.member.Member;
 import UMC.WithYou.domain.notice.Notice;
 import UMC.WithYou.domain.notice.NoticeCheck;
+import UMC.WithYou.repository.member.MemberRepository;
 import UMC.WithYou.repository.notice.NoticeCheckRepository;
 import UMC.WithYou.repository.notice.NoticeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 
 @Service
@@ -19,16 +23,24 @@ public class NoticeCheckCommandServiceImpl implements NoticeCheckCommandService{
 
     private final NoticeCheckRepository noticeCheckRepository;
     private final NoticeRepository noticeRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     @Transactional
-    public NoticeCheck checkBox(Long noticeId){
+    public NoticeCheck checkBox(Long noticeId, Long memberId){
         Notice notice= noticeRepository.findById(noticeId)
                 .orElseThrow(()->new CommonErrorHandler(ErrorStatus._NOTICE_NOT_FOUND));
-        NoticeCheck noticeCheck=noticeCheckRepository.findByNotice(notice).get();
+        Member member=memberRepository.findById(memberId)
+                .orElseThrow(()->new CommonErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        NoticeCheck newNoticeCheck= NoticeCheckConverter.toChangeNoticeCheck(noticeCheck);
-        noticeCheckRepository.save(newNoticeCheck);
-        return newNoticeCheck;
+        Optional<NoticeCheck> noticeCheck=noticeCheckRepository.findByMemberAndNotice(member,notice);
+        NoticeCheck newNoticeCheck;
+        if (noticeCheck.isPresent()){
+            newNoticeCheck = NoticeCheckConverter.toChangeNoticeCheck(noticeCheck.get(), member, notice);
+        }
+        else{
+            newNoticeCheck = NoticeCheckConverter.toJoinDTO(notice, member);
+        }
+        return noticeCheckRepository.save(newNoticeCheck);
     }
 }

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCommandServiceImpl.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCommandServiceImpl.java
@@ -1,13 +1,20 @@
 package UMC.WithYou.service.notice;
 
+import UMC.WithYou.common.apiPayload.code.status.ErrorStatus;
+import UMC.WithYou.common.apiPayload.exception.handler.CommonErrorHandler;
 import UMC.WithYou.converter.NoticeCheckConverter;
 import UMC.WithYou.converter.NoticeConverter;
+import UMC.WithYou.domain.member.Member;
 import UMC.WithYou.domain.notice.Notice;
 import UMC.WithYou.domain.notice.NoticeCheck;
+import UMC.WithYou.domain.travel.Travel;
 import UMC.WithYou.dto.NoticeCheckResponseDTO;
 import UMC.WithYou.dto.NoticeRequestDTO;
+import UMC.WithYou.repository.TravelRepository;
+import UMC.WithYou.repository.member.MemberRepository;
 import UMC.WithYou.repository.notice.NoticeCheckRepository;
 import UMC.WithYou.repository.notice.NoticeRepository;
+import UMC.WithYou.repository.notice.NoticeRepositoryCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,27 +30,29 @@ public class NoticeCommandServiceImpl implements NoticeCommandService{
 
     private final NoticeRepository noticeRepository;
     private final NoticeCheckRepository noticeCheckRepository;
+    private final NoticeRepositoryCustom noticeRepositoryCustom;
+    private final MemberRepository memberRepository;
+    private final TravelRepository travelRepository;
 
     private static boolean isBetween(LocalDateTime dateTime, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         return dateTime.isAfter(startDateTime) && dateTime.isBefore(endDateTime);
     }
 
-
     @Override
     public List<NoticeCheckResponseDTO.ShortResponseDto> getDateNotice(Long travelId, LocalDateTime checkDate){
         List<NoticeCheckResponseDTO.ShortResponseDto> results = new ArrayList<>();
-//        List<Notice> notices=noticeRepository.findByTravelLogFetchJoinMember(travelId);
-//
-//        for(Notice notice : notices){
-//            if (!isBetween(checkDate,notice.getStartDate(),notice.getEndDate()))
-//                break;
-//
-//            List<NoticeCheck> noticeChecks=noticeCheckRepository
-//                    .findAllByIsCheckedIsTrueAndNotice(notice);
-//
-//            NoticeCheckResponseDTO.ShortResponseDto check = NoticeConverter.toSearch(notice, noticeChecks.size());
-//            results.add(check);
-//        }
+        List<Notice> notices=noticeRepositoryCustom.findByTravelLogFetchJoinMember(travelId);
+
+        for(Notice notice : notices){
+            if (!isBetween(checkDate,notice.getStartDate(),notice.getEndDate()))
+                break;
+
+            List<NoticeCheck> noticeChecks=noticeCheckRepository
+                    .findAllByIsCheckedIsTrueAndNotice(notice);
+
+            NoticeCheckResponseDTO.ShortResponseDto check = NoticeConverter.toSearch(notice, noticeChecks.size());
+            results.add(check);
+        }
         return results;
     }
 
@@ -51,26 +60,28 @@ public class NoticeCommandServiceImpl implements NoticeCommandService{
     @Override
     public List<NoticeCheckResponseDTO.ShortResponseDto> getTravelNotice(Long travelId){
         List<NoticeCheckResponseDTO.ShortResponseDto> results = new ArrayList<>();
-//        List<Notice> notices=noticeRepository.findByTravelLogFetchJoinMember(travelId);
-//
-//        for(Notice notice : notices){
-//            List<NoticeCheck> noticeChecks=noticeCheckRepository
-//                    .findAllByIsCheckedIsTrueAndNotice(notice);
-//
-//            NoticeCheckResponseDTO.ShortResponseDto check = NoticeConverter.toSearch(notice, noticeChecks.size());
-//            results.add(check);
-//        }
+        List<Notice> notices=noticeRepositoryCustom.findByTravelLogFetchJoinMember(travelId);
+
+        for(Notice notice : notices){
+            List<NoticeCheck> noticeChecks=noticeCheckRepository
+                    .findAllByIsCheckedIsTrueAndNotice(notice);
+
+            NoticeCheckResponseDTO.ShortResponseDto check = NoticeConverter.toSearch(notice, noticeChecks.size());
+            results.add(check);
+        }
         return results;
     }
 
     @Override
     @Transactional
     public Notice createNotice(NoticeRequestDTO.JoinDto request){
-        Notice newNotice= NoticeConverter.toNotice(request);
-        Notice notice=noticeRepository.save(newNotice);
+        Member member = memberRepository.findById(request.getMemberId())
+                .orElseThrow(()->new CommonErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Travel travel = travelRepository.findById(request.getLogId())
+                .orElseThrow(()->new CommonErrorHandler(ErrorStatus.TRAVEL_LOG_NOT_FOUND));
 
-        NoticeCheck newNoticeCheck= NoticeCheckConverter.toJoinDTO(notice);
-        noticeCheckRepository.save(newNoticeCheck);
+        Notice newNotice= NoticeConverter.toNotice(request,member,travel);
+        Notice notice=noticeRepository.save(newNotice);
 
         return notice;
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#22 

## 📝 작업 내용

- member entity 연관관계 추가
- travel entity 연관관계 추가


## ✅ 테스트 결과 스크린샷

## 💬 리뷰 중점 사안(선택)
![스크린샷 2024-02-03 003949](https://github.com/UMC-with-you/WithYouServer/assets/72841908/2724d7f4-23df-4346-a451-5083cb566560)
notice에 체크한 사람이 취소하거나 새로 체크할 때 공통으로 사용할 수 있게끔 notice 체크박스 API 수정 사항
