### PR TITLE
[FIX]#22 noticeCheck의 체크박스 API

### DIFF
--- a/src/main/java/UMC/WithYou/controller/NoticeController.java
+++ b/src/main/java/UMC/WithYou/controller/NoticeController.java
@@ -30,7 +30,7 @@ public class NoticeController {
 
     private final NoticeCommandService noticeCommandService;
 
-    @Operation(summary="notice 생성 API")
+    @Operation(summary="notice 생성 API(0: 여행전, 1: 여행중, 2: 여행후)")
     @PostMapping
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE2000",description = "OK, 성공"),
@@ -85,19 +85,17 @@ public class NoticeController {
         return ApiResponse.onSuccess(notices);
     }
 
-    @Operation(summary="날짜에 따른 notice 모두 조회 API")
-    @GetMapping("/date/{travelId}/{checkDate}")
+    @Operation(summary="state 에 따른 notice 모두 조회 API")
+    @GetMapping("/date/{travelId}")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE2000",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TRAVEL4003", description = "해당 travel log가 없습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "logId", description = "travel log 의 아이디, path variable 입니다!"),
-            @Parameter(name = "checkDate", description = "현재 날짜, path variable 입니다!"),
     })
-    public ApiResponse<List<NoticeCheckResponseDTO.ShortResponseDto>> getDateNotice
-            (@PathVariable Long travelId, @PathVariable LocalDateTime checkDate){
-        List<NoticeCheckResponseDTO.ShortResponseDto> notices=noticeCommandService.getDateNotice(travelId,checkDate);
+    public ApiResponse<List<NoticeCheckResponseDTO.ShortResponseDto>> getDateNotice(@PathVariable Long travelId){
+        List<NoticeCheckResponseDTO.ShortResponseDto> notices=noticeCommandService.getDateNotice(travelId);
         return ApiResponse.onSuccess(notices);
     }
 

--- a/src/main/java/UMC/WithYou/converter/NoticeCheckConverter.java
+++ b/src/main/java/UMC/WithYou/converter/NoticeCheckConverter.java
@@ -9,7 +9,7 @@ import UMC.WithYou.dto.NoticeResponseDTO;
 
 public class NoticeCheckConverter {
 
-    public static NoticeCheckResponseDTO.ResultDto toResultDTO(NoticeCheck notice){ //조회용
+    public static NoticeCheckResponseDTO.ResultDto toResultDTO(NoticeCheck notice){
         return NoticeCheckResponseDTO.ResultDto.builder()
                 .noticeId(notice.getId())
                 .createdAt(notice.getCreatedAt())
@@ -31,7 +31,7 @@ public class NoticeCheckConverter {
 
     public static NoticeCheck toJoinDTO(Notice notices,Member member){
         return NoticeCheck.builder()
-                .isChecked(false)
+                .isChecked(true)
                 .member(member)
                 .notice(notices)
                 .build();

--- a/src/main/java/UMC/WithYou/converter/NoticeConverter.java
+++ b/src/main/java/UMC/WithYou/converter/NoticeConverter.java
@@ -22,9 +22,11 @@ public class NoticeConverter {
                 .build();
     }
 
-    public static Notice toFixNotice(NoticeRequestDTO.FixDto request){
+    public static Notice toFixNotice(NoticeRequestDTO.FixDto request,Member member,Travel travel){
         return Notice.builder()
                 .state(request.getState())
+                .member(member)
+                .travel(travel)
                 .id(request.getNoticeId())
                 .content(request.getContent())
                 .build();

--- a/src/main/java/UMC/WithYou/domain/notice/Notice.java
+++ b/src/main/java/UMC/WithYou/domain/notice/Notice.java
@@ -26,7 +26,7 @@ public class Notice extends BaseEntity {
 
     private String content;
 
-    private int state; //1: 여행전, 2: 여행중, 3: 여행후
+    private int state; //0: 여행전, 1: 여행중, 2: 여행후
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="member_id")

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCommandService.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCommandService.java
@@ -19,5 +19,5 @@ public interface NoticeCommandService {
 
     List<NoticeCheckResponseDTO.ShortResponseDto> getTravelNotice(Long travelId);
 
-    List<NoticeCheckResponseDTO.ShortResponseDto> getDateNotice(Long travelId, LocalDateTime checkDate);
+    List<NoticeCheckResponseDTO.ShortResponseDto> getDateNotice(Long travelId);
 }

--- a/src/main/java/UMC/WithYou/service/notice/NoticeCommandServiceImpl.java
+++ b/src/main/java/UMC/WithYou/service/notice/NoticeCommandServiceImpl.java
@@ -39,16 +39,21 @@ public class NoticeCommandServiceImpl implements NoticeCommandService{
     }
 
     @Override
-    public List<NoticeCheckResponseDTO.ShortResponseDto> getDateNotice(Long travelId, LocalDateTime checkDate){
+    public List<NoticeCheckResponseDTO.ShortResponseDto> getDateNotice(Long travelId){
+        Travel travel = travelRepository.findById(travelId)
+                .orElseThrow(()->new CommonErrorHandler(ErrorStatus.TRAVEL_LOG_NOT_FOUND));
+        int states=travel.getStatus().ordinal();
+        System.out.println(states);
+
         List<NoticeCheckResponseDTO.ShortResponseDto> results = new ArrayList<>();
         List<Notice> notices=noticeRepositoryCustom.findByTravelLogFetchJoinMember(travelId);
 
         for(Notice notice : notices){
-//            if (!isBetween(checkDate,notice.getStartDate(),notice.getEndDate()))
-//                break;
+            System.out.println(notice.getState());
+            if (notice.getState()!=states)
+                continue;
 
-            List<NoticeCheck> noticeChecks=noticeCheckRepository
-                    .findAllByIsCheckedIsTrueAndNotice(notice);
+            List<NoticeCheck> noticeChecks=noticeCheckRepository.findAllByIsCheckedIsTrueAndNotice(notice);
 
             NoticeCheckResponseDTO.ShortResponseDto check = NoticeConverter.toSearch(notice, noticeChecks.size());
             results.add(check);
@@ -97,7 +102,7 @@ public class NoticeCommandServiceImpl implements NoticeCommandService{
     @Override
     public Notice fix(NoticeRequestDTO.FixDto request){
         Notice notice= noticeRepository.findById(request.getNoticeId()).get();
-        Notice newNotice=NoticeConverter.toFixNotice(request);
+        Notice newNotice=NoticeConverter.toFixNotice(request,notice.getMember(),notice.getTravel());
 
         noticeRepository.save(newNotice);
         return notice;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #22 

## 📝 작업 내용
일단은 travelId랑 받아오기
->이 travel이 어떤 status를 가지는 지 가지고오기

-> travelId에 해당하는 notice들 끌고오기
->해당하는 notice에서 status에 해당하는 notice들만 들고와서 리턴


## ✅ 테스트 결과 스크린샷
<테스트시나리오>
member를 만든다(1)
travel을 만든다(1)->ongoing으로
notice를 만든다(1)->1번으로(member1과 travel1로)
->notice get

noticeCheck를 한다(1) (notice1과 member1로)  - 아무것도 없을 때 추가
->notice get
noticeCheck를 한다(1) (notice1과 member1로) - 상태를 바꾸는 게 제대로 되는가(업데이트)
->notice get

## 💬 리뷰 중점 사안(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
