### PR TITLE
[FIX]#99 modify addTravelMember method not to add member twice

### DIFF
--- a/src/main/java/UMC/WithYou/domain/travel/Travel.java
+++ b/src/main/java/UMC/WithYou/domain/travel/Travel.java
@@ -73,7 +73,6 @@ public class Travel extends BaseEntity {
     }
     public List<Member> getTravelMembers(){
         List<Member> travelMembers = new ArrayList<>();
-        travelMembers.add(this.member);
         for (Traveler traveler : getTravelers()){
             travelMembers.add(traveler.getMember());
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #48 

## 📝 작업 내용

> 여행 로그 멤버 조회 시, 로그를 생성한 유저를 중첩해서 조회되는 로직 수정

## ✅ 테스트 결과 스크린샷

## 💬 리뷰 중점 사안(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
